### PR TITLE
Implement fetch method

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,32 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+When you have an environment variable that is required - perhaps with code like:
+
+```ruby
+# in config/application.rb
+module MyApp
+  class Application < Rails::Application
+    config.x.redis_url = ENV.fetch("REDIS_URL")
+  end
+end
+```
+
+When you run `rails assets:precompile` you'll always need to have a `REDIS_URL` set or else loading
+the application environment will fail. You can update your initializer to do something like:
+
+```ruby
+config.x.redis_url = RequiredEnvFetcher.fetch("REDIS_URL")
+```
+
+Now you can run `SKIP_REQUIRED_ENV_VAR_ENFORCEMENT=true rails assets:precompile` and so long as none of
+your assets rely on the redis URL they will be able to compile.
+
+If you need a specific default value (for example, if the value needs to be a valid URL) you can do:
+
+```ruby
+config.x.redis_url = RequiredEnvFetcher.fetch("REDIS_URL", "http://example.com")
+```
 
 ## Development
 

--- a/lib/required_env_fetcher.rb
+++ b/lib/required_env_fetcher.rb
@@ -2,6 +2,12 @@
 
 require "required_env_fetcher/version"
 
-# Top-level gem module
 module RequiredEnvFetcher
+  def self.fetch(key, default = nil)
+    if ENV["SKIP_REQUIRED_ENV_VAR_ENFORCEMENT"] == "true"
+      ENV.fetch(key, default || "")
+    else
+      ENV.fetch(key)
+    end
+  end
 end

--- a/required_env_fetcher.gemspec
+++ b/required_env_fetcher.gemspec
@@ -51,6 +51,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.12"
 
+  spec.add_development_dependency "climate_control"
   spec.add_development_dependency "ezcater_rubocop", "0.58.0"
   spec.add_development_dependency "overcommit"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/required_env_fetcher_spec.rb
+++ b/spec/required_env_fetcher_spec.rb
@@ -1,7 +1,53 @@
 # frozen_string_literal: true
 
 RSpec.describe RequiredEnvFetcher do
-  it "has a version number" do
-    expect(RequiredEnvFetcher::VERSION).not_to be nil
+  describe ".fetch" do
+    let(:key) { "INTERESTING_THING" }
+
+    context "when the key we're fetching is set in the environment" do
+      subject { described_class.fetch(key) }
+
+      let(:value) { "some value" }
+
+      around do |example|
+        ClimateControl.modify(key => value) do
+          example.run
+        end
+      end
+
+      it { is_expected.to eq value }
+    end
+
+    context "when the key we're fetching is not set in the environment" do
+      context "and we're allowing required environment variables to get default values" do
+        around do |example|
+          ClimateControl.modify(SKIP_REQUIRED_ENV_VAR_ENFORCEMENT: "true") do
+            example.run
+          end
+        end
+
+        context "and there's a default supplied" do
+          subject { described_class.fetch("SETTING", default) }
+
+          let(:default) { "some default" }
+
+          it { is_expected.to eq default }
+        end
+
+        context "and there's no default supplied" do
+          subject { described_class.fetch("SETTING") }
+
+          it { is_expected.to eq "" }
+        end
+      end
+
+      context "and we're not allowing required environment variables to get default values" do
+        it "raises an error" do
+          expect do
+            described_class.fetch("SETTING", "a default")
+          end.to raise_error
+        end
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+require "climate_control"
 require "simplecov"
 SimpleCov.start
 


### PR DESCRIPTION
## What did we change?

Implement fetch method.

## Why are we doing this?

In certain situations it makes sense to allow default values of environment variables that are otherwise required. For example, imagine we're precompiling assets as part of CI when we don't have access to some environment variables we require for the app be up and accepting requests, but aren't required for asset compilation. Using this library we can designate it safe to use default values in those situations.

## How was it tested?
- [X] Specs
- [X] Locally
- [ ] Staging