### PR TITLE
Update development bundler requirement to mitigate CVE-2020-36327

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
 * @ezcater/developer-experience
-
-.github/CHANGELOG @ezcater/admins

--- a/required_env_fetcher.gemspec
+++ b/required_env_fetcher.gemspec
@@ -49,7 +49,7 @@ Gem::Specification.new do |spec|
   spec.executables   = []
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.12"
+  spec.add_development_dependency "bundler", "~> 2.3.8"
 
   spec.add_development_dependency "climate_control"
   spec.add_development_dependency "ezcater_rubocop", "0.58.0"


### PR DESCRIPTION
## What did we change?

Updated the bundler dev dep.

Also, fix up CODEOWNERS to accurately reflect current ownership.

## Why are we doing this?

To mitigate CVE-2020-36327

## How was it tested?
- [ ] Specs
- [ ] Locally
- [ ] Staging