### PR TITLE
Update rake to deal with CVE-2020-8130

### DIFF
--- a/required_env_fetcher.gemspec
+++ b/required_env_fetcher.gemspec
@@ -54,7 +54,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "climate_control"
   spec.add_development_dependency "ezcater_rubocop", "0.58.0"
   spec.add_development_dependency "overcommit"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13.0.6"
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "rspec_junit_formatter", "0.2.2"
   spec.add_development_dependency "simplecov"


### PR DESCRIPTION
## What did we change?

We updated rake to the latest release

## Why are we doing this?

To mitigate CVE-2020-8130

## How was it tested?
- [ ] Specs
- [ ] Locally
- [ ] Staging