### PR TITLE
Setup a GitHub Action that uses the RubyGems [trusted publishing](htt…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         # We only care about rubocop against the latest ruby
-        ruby: ['3.2.2']
+        ruby: ['3.4.4']
 
     steps:
       - name: Checkout the code
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.7.8', '3.0.6', '3.1.4', '3.2.2']
+        ruby: ['3.2.8', '3.3.8', '3.4.4']
 
     steps:
       - name: Checkout the code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Release Gem
+on: workflow_dispatch
+
+jobs:
+  push:
+    name: Push gem to RubyGems.org
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
+      contents: write # IMPORTANT: this permission is required for `rake release` to push the release tag
+
+    steps:
+      # Set up
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ruby
+
+      # Release
+      - uses: rubygems/release-gem@v1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,8 @@
 inherit_gem:
   ezcater_rubocop: conf/rubocop_gem.yml
+
+plugins:
+  - rubocop-capybara
+
+AllCops:
+    TargetRubyVersion: 3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # required_env_fetcher
 
+## v0.x.x
+- Remove support for < Ruby 3.2
+- Switch to using RubyGems trusted publishing instead of manual releases
+
 ## v0.1.0
 - Initial version

--- a/README.md
+++ b/README.md
@@ -59,10 +59,11 @@ interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`.
 
-To release a new version, update the version number in `version.rb`, and then
-run `bundle exec rake release`, which will create a git tag for the version,
-push git commits and tags, and push the `.gem` file to
-[rubygems.org](https://rubygems.org)
+To release a new version, first ensure that the CHANGELOG.md and `version.rb` files are updated. In the
+GitHub UI for this repository, navigate to `Actions -> Release Gem` and click `Run workflow`. Select
+the branch you intend to release (most likely `main`). The action will create and push a git tag then
+release the new version to Rubygems.org using the [trusted publishing](https://guides.rubygems.org/trusted-publishing/)
+feature.
 .
 
 ## Contributing

--- a/required_env_fetcher.gemspec
+++ b/required_env_fetcher.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |spec|
   # should probably update in a separate PR
   spec.required_ruby_version = ">= 3.2"
 
-  spec.add_development_dependency "bundler", "~> 2.5.17"
+  spec.add_development_dependency "bundler", "~> 2.6.9"
 
   spec.add_development_dependency "climate_control"
   spec.add_development_dependency "ezcater_rubocop", "~> 6.0.2"

--- a/required_env_fetcher.gemspec
+++ b/required_env_fetcher.gemspec
@@ -54,7 +54,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.6.9"
 
   spec.add_development_dependency "climate_control"
-  spec.add_development_dependency "ezcater_rubocop", "~> 6.0.2"
+  spec.add_development_dependency "ezcater_rubocop", "~> 9.0.0"
   spec.add_development_dependency "overcommit"
   spec.add_development_dependency "rake", "~> 13.0.6"
   spec.add_development_dependency "rspec", "~> 3.4"

--- a/required_env_fetcher.gemspec
+++ b/required_env_fetcher.gemspec
@@ -49,9 +49,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   # This is to match inherited settings from ezcater_rubocop which we
   # should probably update in a separate PR
-  spec.required_ruby_version = ">= 2.6"
+  spec.required_ruby_version = ">= 3.2"
 
-  spec.add_development_dependency "bundler", "~> 2.4.19"
+  spec.add_development_dependency "bundler", "~> 2.5.17"
 
   spec.add_development_dependency "climate_control"
   spec.add_development_dependency "ezcater_rubocop", "~> 6.0.2"


### PR DESCRIPTION
## What did we change?
Setup a GitHub Action that uses the RubyGems [trusted publishing](https://guides.rubygems.org/trusted-publishing/) feature to  publish the gem without requiring long-lived secrets. A trusted publisher has already been added on the RubyGems side for this gem.

## Why are we doing this?
To [reduce the supply chain risk](https://ezcater.atlassian.net/wiki/spaces/TRUST/pages/5259591681/Mitigating+Supply+Chain+Risk+Centralizing+Ownership+and+Publication+of+ezCater+Ruby+Gems) that comes with multiple people having push access with personal RubyGems accounts. Once we know this works we can remove everyone except the ezCater-controlled RubyGems account from the owners list.

## How was it tested?
- [ ] Specs
- [ ] Locally
- [ ] Staging
