### PR TITLE
chore: pin GitHub Actions to commit SHAs [PinnR]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Ruby ${{ matrix.ruby }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a # v1.302.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler: latest
@@ -46,10 +46,10 @@ jobs:
 
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Ruby ${{ matrix.ruby }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a # v1.302.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler: latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,11 +36,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@65216971a11ded447a6b76263d5a144519e5eee1 # codeql-bundle-v2.25.2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@65216971a11ded447a6b76263d5a144519e5eee1 # codeql-bundle-v2.25.2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -66,6 +66,6 @@ jobs:
     #     ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@65216971a11ded447a6b76263d5a144519e5eee1 # codeql-bundle-v2.25.2
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Dependency Review
-        uses: actions/dependency-review-action@v3
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
           # Possible values: "critical", "high", "moderate", "low" 
           fail-on-severity: high

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       # Set up
       - uses: actions/checkout@v4
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a # v1.302.0
         with:
           bundler-cache: true
           ruby-version: ruby


### PR DESCRIPTION
## PinnR: GitHub Actions Security Update

This PR pins GitHub Actions to specific commit SHAs to improve supply chain security.

### Why?

Floating tags like `v3` or branches like `main` can be moved to point to different commits, potentially introducing malicious code. Pinning to SHAs ensures the exact code version is used.

### Changes

| File | Action | Change |
|------|--------|--------|
| `ci.yml` | `actions/checkout` | `v3` → `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (`v6.0.2`) |
| `ci.yml` | `ruby/setup-ruby` | `v1` → `7372622e62b60b3cb750dcd2b9e32c247ffec26a` (`v1.302.0`) |
| `ci.yml` | `actions/checkout` | `v3` → `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (`v6.0.2`) |
| `ci.yml` | `ruby/setup-ruby` | `v1` → `7372622e62b60b3cb750dcd2b9e32c247ffec26a` (`v1.302.0`) |
| `codeql.yml` | `actions/checkout` | `v3` → `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (`v6.0.2`) |
| `codeql.yml` | `github/codeql-action/init` | `v2` → `65216971a11ded447a6b76263d5a144519e5eee1` (`codeql-bundle-v2.25.2`) |
| `codeql.yml` | `github/codeql-action/autobuild` | `v2` → `65216971a11ded447a6b76263d5a144519e5eee1` (`codeql-bundle-v2.25.2`) |
| `codeql.yml` | `github/codeql-action/analyze` | `v2` → `65216971a11ded447a6b76263d5a144519e5eee1` (`codeql-bundle-v2.25.2`) |
| `dependency-review.yml` | `actions/checkout` | `v3` → `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (`v6.0.2`) |
| `dependency-review.yml` | `actions/dependency-review-action` | `v3` → `2031cfc080254a8a887f58cffee85186f0e49e48` (`v4.9.0`) |
| `release.yml` | `ruby/setup-ruby` | `v1` → `7372622e62b60b3cb750dcd2b9e32c247ffec26a` (`v1.302.0`) |

### Note

If this PR is closed without merging, the branch `pinnR/GHA-Update-2026-04-16` will need to be deleted manually.

---
🤖 Generated by [PinnR](https://github.com/CyBirdSecurity/pinnr)